### PR TITLE
Update open-source-cookies-recipe.md

### DIFF
--- a/open-source-cookies-recipe.md
+++ b/open-source-cookies-recipe.md
@@ -6,7 +6,7 @@ Copyright (C) 2024 by Peter Martin. All Rights Reserved.
 
 ## Ingredients
 - 165 grams of white brown sugar
-- 250 grams of margarine
+- 250 grams of butter
 - 180 grams flour
 - 150 grams whole wheat flour
 - 2 teaspoons of baking powder


### PR DESCRIPTION
Please use real butter instead of margarine.

Butter's high fat content is also what gives baked goods their texture. Margarine, which can contain more water and less fat, may make thin cookies that spread out while baking (and may burn).
